### PR TITLE
Updated to file_config format

### DIFF
--- a/cumulus_library_umls/manifest.toml
+++ b/cumulus_library_umls/manifest.toml
@@ -1,6 +1,6 @@
 study_prefix = "umls"
 
-[table_builder_config]
+[file_config]
 file_names = [
     "umls_builder.py",
     "static_builder.py",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "cumulus-library-umls"
 requires-python = ">= 3.11"
 dependencies = [
-    "cumulus-library >= 4.1.3",
+    "cumulus-library >= 4.1.3, < 7.0",
     "platformdirs >= 4.3.8"
 ]
 description = "A Unified Medical Language System® Metathesaurus study for the Cumulus project"


### PR DESCRIPTION
This removes the deprecated `table_builder_config` entry in the manifest in favor of the `file_config` equivalent.